### PR TITLE
Add a missing line to staging release using Hermes

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -217,6 +217,7 @@ dependencies {
         def hermesPath = "../../node_modules/hermes-engine/android/";
         debugImplementation files(hermesPath + "hermes-debug.aar")
         releaseImplementation files(hermesPath + "hermes-release.aar")
+        stagingreleaseImplementation files(hermesPath + "hermes-release.aar")
     } else {
         implementation jscFlavor
     }


### PR DESCRIPTION
#### 📄&nbsp; Description:

When the staging release task finished the App crashes because doesn't have Hermes engine in the bundle.

---

#### ✔️&nbsp; Performed Tasks:

* Add Hermes bundle to staging release

---
